### PR TITLE
Update component to run with jdk 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -470,7 +470,7 @@
         <carbon.registry.version.range>[1.0.0, 5.0.0)</carbon.registry.version.range>
         <carbon.analytics.common.version>5.0.11</carbon.analytics.common.version>
         <carbon.analytics.common.version.range>[5.0.0, 6.0.0)</carbon.analytics.common.version.range>
-        <carbon.p2.plugin.version>1.6.1-SNAPSHOT</carbon.p2.plugin.version> <!-- maven-tools branch: master_java10 -->
+        <carbon.p2.plugin.version>5.1.2</carbon.p2.plugin.version>
         <securevault.version>1.0.0-wso2v2</securevault.version>
         <stax.api.version>1.0.1</stax.api.version>
         <axiom.version>1.2.19</axiom.version>


### PR DESCRIPTION
## Purpose
> Update component to run with JDK 11

Existing implementation uses reflection to access methods in OperatingSystemMXBean in com.sun.management component to get the system related properties such as processCpuLoad etc. From JDK 11, access through reflection to internal components is restricted. so acceesing the method in OperatingSystemMXBean is failing in JDK 11. This pr fixes this issue