### PR TITLE
Revert OperatingSystemMXBean to previous impl and update the logic

### DIFF
--- a/components/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/metric/OperatingSystemMetricSet.java
+++ b/components/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/metric/OperatingSystemMetricSet.java
@@ -17,6 +17,9 @@ package org.wso2.carbon.metrics.impl.metric;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -27,7 +30,6 @@ import org.slf4j.LoggerFactory;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricSet;
-import com.sun.management.UnixOperatingSystemMXBean;
 
 /**
  * A set of gauges for Operating System usage, including stats on load average, cpu load, file descriptors etc
@@ -63,132 +65,131 @@ public class OperatingSystemMetricSet implements MetricSet {
                 logger.debug("System Load Average is not available as an Operating System Metric");
             }
         }
-        
-        Gauge<Long> openFileDescriptorCountGauge;
-        Gauge<Long> maxFileDescriptorCountGauge;
-        // openFileDescriptorCountGauge and maxFileDescriptorCountGauge are only supported in UNIX OS
-        try {
-            openFileDescriptorCountGauge = new Gauge<Long>() {
-                @Override
-                public Long getValue() {
-                    return ((UnixOperatingSystemMXBean) mxBean).getOpenFileDescriptorCount();
-                }
-            };
-            maxFileDescriptorCountGauge = new Gauge<Long>() {
-                @Override
-                public Long getValue() {
-                    return ((UnixOperatingSystemMXBean) mxBean).getMaxFileDescriptorCount();
-                }
-            };
 
-        } catch (ClassCastException e) {
-            // Since these two properties are supported only on unix os, set the value to 0 for other OS
-            openFileDescriptorCountGauge = new EmptyGaugeLong();
-            maxFileDescriptorCountGauge = new EmptyGaugeLong();
-
+        Gauge<Long> openFileDescriptorCountGauge = getLongGauge("getOpenFileDescriptorCount");
+        if (openFileDescriptorCountGauge != null) {
+            gauges.put("file.descriptor.open.count", openFileDescriptorCountGauge);
         }
 
-        gauges.put("file.descriptor.open.count", openFileDescriptorCountGauge);
-        if (logger.isDebugEnabled()) {
-            logger.debug("file.descriptor.open.count : " + openFileDescriptorCountGauge.getValue());
+        Gauge<Long> maxFileDescriptorCountGauge = getLongGauge("getMaxFileDescriptorCount");
+        if (maxFileDescriptorCountGauge != null) {
+            gauges.put("file.descriptor.max.count", maxFileDescriptorCountGauge);
         }
 
-        gauges.put("file.descriptor.max.count", maxFileDescriptorCountGauge);
-        if (logger.isDebugEnabled()) {
-            logger.debug("file.descriptor.max.count : " + maxFileDescriptorCountGauge.getValue());
+        Gauge<Double> processCpuLoadGauge = getDoubleGauge("getProcessCpuLoad");
+        if (processCpuLoadGauge != null) {
+            gauges.put("cpu.load.process", processCpuLoadGauge);
         }
 
-        Gauge<Double> processCpuLoadGauge = new Gauge<Double>() {
-            @Override
-            public Double getValue() {
-                return ((com.sun.management.OperatingSystemMXBean) mxBean).getProcessCpuLoad();
-            }
-        };
-
-        gauges.put("cpu.load.process", processCpuLoadGauge);
-        if (logger.isDebugEnabled()) {
-            logger.debug("cpu.load.process : " + processCpuLoadGauge.getValue());
+        Gauge<Double> systemCpuLoadGauge = getDoubleGauge("getSystemCpuLoad");
+        if (systemCpuLoadGauge != null) {
+            gauges.put("cpu.load.system", systemCpuLoadGauge);
         }
 
-        Gauge<Double> systemCpuLoadGauge = new Gauge<Double>() {
-            @Override
-            public Double getValue() {
-                return ((com.sun.management.OperatingSystemMXBean) mxBean).getSystemCpuLoad();
-            }
-        };
-
-        gauges.put("cpu.load.system", systemCpuLoadGauge);
-        if (logger.isDebugEnabled()) {
-            logger.debug("cpu.load.system : " + systemCpuLoadGauge.getValue());
+        Gauge<Long> freePhysicalMemorySizeGauge = getLongGauge("getFreePhysicalMemorySize");
+        if (freePhysicalMemorySizeGauge != null) {
+            gauges.put("physical.memory.free.size", freePhysicalMemorySizeGauge);
         }
 
-        Gauge<Long> freePhysicalMemorySizeGauge = new Gauge<Long>() {
-            @Override
-            public Long getValue() {
-                return ((com.sun.management.OperatingSystemMXBean) mxBean).getFreePhysicalMemorySize();
-            }
-        };
-
-        gauges.put("physical.memory.free.size", freePhysicalMemorySizeGauge);
-        if (logger.isDebugEnabled()) {
-            logger.debug("physical.memory.free.size : " + freePhysicalMemorySizeGauge.getValue());
+        Gauge<Long> totalPhysicalMemorySizeGauge = getLongGauge("getTotalPhysicalMemorySize");
+        if (totalPhysicalMemorySizeGauge != null) {
+            gauges.put("physical.memory.total.size", totalPhysicalMemorySizeGauge);
         }
 
-        Gauge<Long> totalPhysicalMemorySizeGauge = new Gauge<Long>() {
-            @Override
-            public Long getValue() {
-                return ((com.sun.management.OperatingSystemMXBean) mxBean).getTotalPhysicalMemorySize();
-            }
-        };
-
-        gauges.put("physical.memory.total.size", totalPhysicalMemorySizeGauge);
-        if (logger.isDebugEnabled()) {
-            logger.debug("physical.memory.total.size : " + totalPhysicalMemorySizeGauge.getValue());
+        Gauge<Long> freeSwapSpaceSizeGauge = getLongGauge("getFreeSwapSpaceSize");
+        if (freeSwapSpaceSizeGauge != null) {
+            gauges.put("swap.space.free.size", freeSwapSpaceSizeGauge);
         }
 
-        Gauge<Long> freeSwapSpaceSizeGauge = new Gauge<Long>() {
-            @Override
-            public Long getValue() {
-                return ((com.sun.management.OperatingSystemMXBean) mxBean).getFreeSwapSpaceSize();
-            }
-        };
-
-        gauges.put("swap.space.free.size", freeSwapSpaceSizeGauge);
-        if (logger.isDebugEnabled()) {
-            logger.debug("swap.space.free.size : " + freeSwapSpaceSizeGauge.getValue());
+        Gauge<Long> totalSwapSpaceSizeGauge = getLongGauge("getTotalSwapSpaceSize");
+        if (totalSwapSpaceSizeGauge != null) {
+            gauges.put("swap.space.total.size", totalSwapSpaceSizeGauge);
         }
 
-        Gauge<Long> totalSwapSpaceSizeGauge = new Gauge<Long>() {
-            @Override
-            public Long getValue() {
-                return ((com.sun.management.OperatingSystemMXBean) mxBean).getTotalSwapSpaceSize();
-            }
-        };
-
-        gauges.put("swap.space.total.size", totalSwapSpaceSizeGauge);
-        if (logger.isDebugEnabled()) {
-            logger.debug("swap.space.total.size : " + totalSwapSpaceSizeGauge.getValue());
-        }
-
-        Gauge<Long> committedVirtualMemorySizeGauge = new Gauge<Long>() {
-            @Override
-            public Long getValue() {
-                return ((com.sun.management.OperatingSystemMXBean) mxBean).getCommittedVirtualMemorySize();
-            }
-        };
-
-        gauges.put("virtual.memory.committed.size", committedVirtualMemorySizeGauge);
-        if (logger.isDebugEnabled()) {
-            logger.debug("virtual.memory.committed.size : " + committedVirtualMemorySizeGauge.getValue());
+        Gauge<Long> committedVirtualMemorySizeGauge = getLongGauge("getCommittedVirtualMemorySize");
+        if (committedVirtualMemorySizeGauge != null) {
+            gauges.put("virtual.memory.committed.size", committedVirtualMemorySizeGauge);
         }
 
         return Collections.unmodifiableMap(gauges);
     }
 
-    static class EmptyGaugeLong implements Gauge{
-        @Override
-        public Long getValue() {
+    private Gauge<Long> getLongGauge(final String methodName) {
+        Object value = null;
+        try {
+            value = invokeMethod(methodName);
+        } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException
+                | InvocationTargetException e) {
+            // Ignore
+            if (logger.isTraceEnabled()) {
+                logger.trace(String.format("Error when invoking %s", methodName), e);
+            }
+        }
+        if (value != null) {
+            // Method is working
+            return new Gauge<Long>() {
+                @Override
+                public Long getValue() {
+                    return invokeLong(methodName);
+                }
+            };
+        }
+        return null;
+    }
+
+    private Gauge<Double> getDoubleGauge(final String methodName) {
+        Object value = null;
+        try {
+            value = invokeMethod(methodName);
+        } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException
+                | InvocationTargetException e) {
+            // Ignore
+            if (logger.isTraceEnabled()) {
+                logger.trace(String.format("Error when invoking %s", methodName), e);
+            }
+        }
+        if (value != null) {
+            // Method is working
+            return new Gauge<Double>() {
+                @Override
+                public Double getValue() {
+                    return invokeDouble(methodName);
+                }
+            };
+        }
+        return null;
+    }
+
+    private Object invokeMethod(String methodName) throws NoSuchMethodException, SecurityException,
+            IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+        final Method method = mxBean.getClass().getDeclaredMethod(methodName);
+        if (!Modifier.isPublic(method.getModifiers())) {
+            method.setAccessible(true);
+        }
+        return method.invoke(mxBean);
+    }
+
+    private long invokeLong(String methodName) {
+        try {
+            return (Long) invokeMethod(methodName);
+        } catch (NoSuchMethodException e) {
             return 0L;
-        }     
+        } catch (IllegalAccessException e) {
+            return 0L;
+        } catch (InvocationTargetException e) {
+            return 0L;
+        }
+    }
+
+    private double invokeDouble(String methodName) {
+        try {
+            return (Double) invokeMethod(methodName);
+        } catch (NoSuchMethodException e) {
+            return -1.0;
+        } catch (IllegalAccessException e) {
+            return -1.0;
+        } catch (InvocationTargetException e) {
+            return -1.0;
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -464,7 +464,7 @@
         <metrics.version.range>[3.1.0, 4.0.0)</metrics.version.range>
         <eclipse.osgi.version>3.11.0.v20160603-1336</eclipse.osgi.version>
         <equinox.osgi.services.version>3.5.100.v20160504-1419</equinox.osgi.services.version>
-        <carbon.kernel.version>4.4.37-SNAPSHOT</carbon.kernel.version> <!-- carbon-kernel branch: 4.4.x_java10 -->
+        <carbon.kernel.version>4.4.7</carbon.kernel.version>
         <carbon.kernel.version.range>[4.0.0, 5.0.0)</carbon.kernel.version.range>
         <!-- Registry Core exports version 1.0.1 -->
         <carbon.registry.version.range>[1.0.0, 5.0.0)</carbon.registry.version.range>


### PR DESCRIPTION
## Purpose
> reverting https://github.com/wso2/carbon-metrics/pull/75 and update OperatingSystemMXBean to work with jdk 11 with minimal code change

This pr change OperatingSystemMXBean to the previous state and only add the following section as a change (add the condition clause). From JDK9 onwards these method were made public. so explicitly calling the setAccessible cause issues in jdk11

        if (!Modifier.isPublic(method.getModifiers())) {
            method.setAccessible(true);
        }