### PR TITLE
Remove wso2. prefix from config namespace

### DIFF
--- a/components/org.wso2.carbon.metrics.core/src/main/java/org/wso2/carbon/metrics/core/Metrics.java
+++ b/components/org.wso2.carbon.metrics.core/src/main/java/org/wso2/carbon/metrics/core/Metrics.java
@@ -47,6 +47,7 @@ import javax.management.ObjectName;
 public class Metrics {
 
     private static final Logger logger = LoggerFactory.getLogger(Metrics.class);
+    private static final String STREAMLINED_METRICS_NAMESPACE = "metrics";
 
     private final boolean enabled;
 
@@ -75,7 +76,12 @@ public class Metrics {
 
         MetricsConfig metricsConfig;
         try {
-            metricsConfig = configProvider.getConfigurationObject(MetricsConfig.class);
+            if (configProvider.getConfigurationObject(STREAMLINED_METRICS_NAMESPACE) != null) {
+                metricsConfig = configProvider
+                            .getConfigurationObject(STREAMLINED_METRICS_NAMESPACE, MetricsConfig.class);
+            } else {
+                metricsConfig = configProvider.getConfigurationObject(MetricsConfig.class);
+            }
         } catch (ConfigurationException e) {
             logger.error("Error loading Metrics Configuration", e);
             metricsConfig = new MetricsConfig();

--- a/components/org.wso2.carbon.metrics.core/src/test/java/org/wso2/carbon/metrics/core/MetricsConfigTest.java
+++ b/components/org.wso2.carbon.metrics.core/src/test/java/org/wso2/carbon/metrics/core/MetricsConfigTest.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class MetricsConfigTest extends BaseMetricTest {
 
-    private static MetricsConfig metricsConfig;
+    static MetricsConfig metricsConfig;
 
     @BeforeClass
     private void load() throws ConfigurationException {

--- a/components/org.wso2.carbon.metrics.core/src/test/java/org/wso2/carbon/metrics/core/MetricsStreamlinedConfigTest.java
+++ b/components/org.wso2.carbon.metrics.core/src/test/java/org/wso2/carbon/metrics/core/MetricsStreamlinedConfigTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.core;
+
+import org.testng.annotations.BeforeClass;
+import org.wso2.carbon.config.ConfigurationException;
+import org.wso2.carbon.metrics.core.config.model.MetricsConfig;
+
+/**
+ * Test Cases for {@link MetricsConfig}.
+ */
+public class MetricsStreamlinedConfigTest extends MetricsConfigTest {
+
+    @BeforeClass
+    private void load() throws ConfigurationException {
+        metricsConfig = TestUtils.getConfigProvider("metrics-reporter2.yaml")
+                .getConfigurationObject(MetricsConfig.class);
+    }
+}

--- a/components/org.wso2.carbon.metrics.core/src/test/resources/conf/metrics-reporter2.yaml
+++ b/components/org.wso2.carbon.metrics.core/src/test/resources/conf/metrics-reporter2.yaml
@@ -1,0 +1,61 @@
+# Copyright 2019 WSO2 Inc. (http://wso2.org)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration file to test metrics with all reporters
+
+# Carbon Metrics Configuration Parameters
+metrics:
+  enabled: true
+
+  jmx:
+    registerMBean: true
+    name: org.wso2.carbon:type=MetricsTest
+
+  reservoir:
+    type: UNIFORM
+    parameters:
+      size: 2048
+      window: 30
+      windowUnit: MINUTES
+      numberOfSignificantValueDigits: 3
+      resetOnSnapshot: true
+
+  reporting:
+    jmx:
+      - name: JMX
+        enabled: true
+        domain: org.wso2.carbon.metrics.test
+
+      # Define another reporter to check whether only one reporter is added with same name
+      - name: JMX
+        enabled: true
+        domain: org.wso2.carbon.metrics.test
+
+    console:
+      - name: Console
+        enabled: true
+        pollingPeriod: 600
+
+    csv:
+      - name: CSV
+        enabled: true
+        location: ${metrics.target}/metrics
+        pollingPeriod: 600
+
+    slf4j:
+      - name: SLF4J
+        enabled: true
+        loggerName: metrics.test
+        markerName: metrics
+        pollingPeriod: 600

--- a/components/org.wso2.carbon.metrics.das.core/src/main/java/org/wso2/carbon/metrics/das/core/DasMetricsExtension.java
+++ b/components/org.wso2.carbon.metrics.das.core/src/main/java/org/wso2/carbon/metrics/das/core/DasMetricsExtension.java
@@ -43,7 +43,7 @@ import java.util.Set;
 public class DasMetricsExtension implements MetricsExtension {
 
     private static final Logger logger = LoggerFactory.getLogger(DasMetricsExtension.class);
-
+    private static final String STREAMLINED_DAS_REPORTER_NS = "metrics.das";
     private String[] names;
 
     /**
@@ -54,7 +54,11 @@ public class DasMetricsExtension implements MetricsExtension {
                          MetricManagementService metricManagementService) {
         MetricsConfig metricsConfig;
         try {
-            metricsConfig = configProvider.getConfigurationObject(MetricsConfig.class);
+            if (configProvider.getConfigurationObject(STREAMLINED_DAS_REPORTER_NS) != null) {
+                metricsConfig = configProvider.getConfigurationObject(STREAMLINED_DAS_REPORTER_NS, MetricsConfig.class);
+            } else {
+                metricsConfig = configProvider.getConfigurationObject(MetricsConfig.class);
+            }
         } catch (ConfigurationException e) {
             logger.error("Error loading Metrics Configuration", e);
             metricsConfig = new MetricsConfig();

--- a/components/org.wso2.carbon.metrics.das.core/src/test/java/org/wso2/carbon/metrics/das/core/MetricsConfigTest.java
+++ b/components/org.wso2.carbon.metrics.das.core/src/test/java/org/wso2/carbon/metrics/das/core/MetricsConfigTest.java
@@ -28,7 +28,7 @@ import org.wso2.carbon.metrics.das.core.config.model.MetricsConfig;
  */
 public class MetricsConfigTest {
 
-    private static MetricsConfig metricsConfig;
+    static MetricsConfig metricsConfig;
 
     @BeforeClass
     private void load() throws ConfigurationException {

--- a/components/org.wso2.carbon.metrics.das.core/src/test/java/org/wso2/carbon/metrics/das/core/MetricsStreamlinedConfigTest.java
+++ b/components/org.wso2.carbon.metrics.das.core/src/test/java/org/wso2/carbon/metrics/das/core/MetricsStreamlinedConfigTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.das.core;
+
+import org.testng.annotations.BeforeClass;
+import org.wso2.carbon.config.ConfigurationException;
+import org.wso2.carbon.metrics.das.core.config.model.MetricsConfig;
+
+/**
+ * Test Cases for {@link MetricsConfig}.
+ */
+public class MetricsStreamlinedConfigTest extends MetricsConfigTest {
+
+
+    @BeforeClass
+    private void load() throws ConfigurationException {
+        System.setProperty("metrics.dataagent.conf", "data.agent.config.yaml");
+        metricsConfig = TestUtils.getConfigProvider("metrics2.yaml").getConfigurationObject(MetricsConfig.class);
+    }
+
+}

--- a/components/org.wso2.carbon.metrics.das.core/src/test/resources/conf/metrics2.yaml
+++ b/components/org.wso2.carbon.metrics.das.core/src/test/resources/conf/metrics2.yaml
@@ -1,0 +1,34 @@
+# Copyright 2016 WSO2 Inc. (http://wso2.org)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration file to test the DAS reporter
+
+# Carbon Metrics Configuration Parameters for DAS Reporters
+metrics.das:
+  das:
+    - &DAS01
+      receiverURL: tcp://localhost:51840
+      # authURL: ssl://localhost:7711
+      type: thrift
+      username: admin
+      password: admin
+      dataAgentConfigPath: ${metrics.dataagent.conf}
+
+  reporting:
+    das:
+      - name: DAS
+        enabled: true
+        source: Carbon-das
+        das: *DAS01
+        pollingPeriod: 600

--- a/components/org.wso2.carbon.metrics.jdbc.core/src/main/java/org/wso2/carbon/metrics/jdbc/core/JdbcMetricsExtension.java
+++ b/components/org.wso2.carbon.metrics.jdbc.core/src/main/java/org/wso2/carbon/metrics/jdbc/core/JdbcMetricsExtension.java
@@ -44,7 +44,7 @@ import java.util.Set;
 public class JdbcMetricsExtension implements MetricsExtension {
 
     private static final Logger logger = LoggerFactory.getLogger(JdbcMetricsExtension.class);
-
+    private static final String STREAMLINED_JDBC_NS = "metrics.jdbc";
     private String[] names;
 
     /**
@@ -55,7 +55,11 @@ public class JdbcMetricsExtension implements MetricsExtension {
                          MetricManagementService metricManagementService) {
         MetricsConfig metricsConfig;
         try {
-            metricsConfig = configProvider.getConfigurationObject(MetricsConfig.class);
+            if (configProvider.getConfigurationObject(STREAMLINED_JDBC_NS) != null) {
+                metricsConfig = configProvider.getConfigurationObject(STREAMLINED_JDBC_NS, MetricsConfig.class);
+            } else {
+                metricsConfig = configProvider.getConfigurationObject(MetricsConfig.class);
+            }
         } catch (ConfigurationException e) {
             logger.error("Error loading Metrics Configuration", e);
             metricsConfig = new MetricsConfig();

--- a/components/org.wso2.carbon.metrics.jdbc.core/src/test/java/org/wso2/carbon/metrics/jdbc/core/MetricsConfigTest.java
+++ b/components/org.wso2.carbon.metrics.jdbc.core/src/test/java/org/wso2/carbon/metrics/jdbc/core/MetricsConfigTest.java
@@ -28,7 +28,7 @@ import org.wso2.carbon.metrics.jdbc.core.config.model.MetricsConfig;
  */
 public class MetricsConfigTest {
 
-    private static MetricsConfig metricsConfig;
+    static MetricsConfig metricsConfig;
 
     @BeforeClass
     private void load() throws ConfigurationException {

--- a/components/org.wso2.carbon.metrics.jdbc.core/src/test/java/org/wso2/carbon/metrics/jdbc/core/MetricsStreamlinedConfigTest.java
+++ b/components/org.wso2.carbon.metrics.jdbc.core/src/test/java/org/wso2/carbon/metrics/jdbc/core/MetricsStreamlinedConfigTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.jdbc.core;
+
+import org.testng.annotations.BeforeClass;
+import org.wso2.carbon.config.ConfigurationException;
+import org.wso2.carbon.metrics.jdbc.core.config.model.MetricsConfig;
+
+/**
+ * Test Cases for {@link MetricsConfig}.
+ */
+public class MetricsStreamlinedConfigTest extends MetricsConfigTest {
+
+    @BeforeClass
+    private void load() throws ConfigurationException {
+        metricsConfig = TestUtils.getConfigProvider("metrics2.yaml").getConfigurationObject(MetricsConfig.class);
+    }
+}

--- a/components/org.wso2.carbon.metrics.jdbc.core/src/test/resources/conf/metrics2.yaml
+++ b/components/org.wso2.carbon.metrics.jdbc.core/src/test/resources/conf/metrics2.yaml
@@ -1,0 +1,46 @@
+# Copyright 2019 WSO2 Inc. (http://wso2.org)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration file to test Metrics JDBC Reporter
+
+# Carbon Metrics Configuration Parameters
+metrics:
+  enabled: true
+
+  # Do not register MBean
+  jmx:
+    registerMBean: false
+
+  reporting:
+    jmx:
+      - enabled: false
+
+# Carbon Metrics Configuration Parameters for JDBC Reporters
+metrics.jdbc:
+  dataSource:
+    - &JDBC01
+      lookupDataSource: true
+      dataSourceName: jdbc/WSO2MetricsDB
+      scheduledCleanup:
+        enabled: true
+        daysToKeep: 2
+        scheduledCleanupPeriod: 10000
+
+  reporting:
+    jdbc:
+      - name: JDBC
+        enabled: true
+        source: Carbon-jdbc
+        dataSource: *JDBC01
+        pollingPeriod: 600

--- a/pom.xml
+++ b/pom.xml
@@ -844,7 +844,7 @@
         <carbon.kernel.version.range>[5.2.0, 6.0.0)</carbon.kernel.version.range>
         <carbon.analytics.common.version>6.0.16</carbon.analytics.common.version>
         <carbon.analytics.common.version.range>[6.0.0, 7.0.0)</carbon.analytics.common.version.range>
-        <carbon.config.version>2.1.4</carbon.config.version>
+        <carbon.config.version>2.1.13</carbon.config.version>
         <carbon.config.version.range>[2.1.0, 3.0.0)</carbon.config.version.range>
         <xerces.impl.version>2.11.0.SP5</xerces.impl.version>
         <slf4j.version>1.7.25</slf4j.version>
@@ -870,7 +870,7 @@
         <libthrift.wso2.version>0.9.2.wso2v1</libthrift.wso2.version>
         <commons-io.wso2.version>2.4.0.wso2v1</commons-io.wso2.version>
         <commons.pool.version>1.5.6.wso2v1</commons.pool.version>
-        <carbon.securevault.version>5.0.10</carbon.securevault.version>
+        <carbon.securevault.version>5.0.14</carbon.securevault.version>
         <carbon.utils.version>2.0.4</carbon.utils.version>
         <osgi.core.api.version>6.0.0</osgi.core.api.version>
         <equinox.app.version>1.3.300.v20150423-1356</equinox.app.version>


### PR DESCRIPTION
## Purpose
$subject
wso2.metrics -> metrics
wso2.metrics.das -> metrics.das
wso2.metrics.jdbc -> metrics.jdbc

## Goals
Streamline configurations as discussed in https://groups.google.com/forum/?hl=en#!topic/siddhi-dev/j3W4mA8jjQ8
 
## Approach
'metrics' is used when parsing YAML file first, then falls back to wso2.metrics

## User stories
N/A

## Release note
N/A

## Documentation
N/A as it is backward compatible

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests - Attached Herewith
 - Integration tests - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDJ 1.8.0_191
 
## Learning
N/A