### PR TITLE
Update h2 dependency version

### DIFF
--- a/components/org.wso2.carbon.metrics.jdbc.core/pom.xml
+++ b/components/org.wso2.carbon.metrics.jdbc.core/pom.xml
@@ -84,7 +84,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
+            <groupId>org.wso2.orbit.com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>

--- a/components/org.wso2.carbon.metrics.jdbc.reporter/pom.xml
+++ b/components/org.wso2.carbon.metrics.jdbc.reporter/pom.xml
@@ -64,7 +64,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
+            <groupId>org.wso2.orbit.com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>

--- a/features/org.wso2.carbon.metrics.jdbc.core.feature/pom.xml
+++ b/features/org.wso2.carbon.metrics.jdbc.core.feature/pom.xml
@@ -39,7 +39,7 @@
             <artifactId>org.wso2.carbon.metrics.jdbc.core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
+            <groupId>org.wso2.orbit.com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>
     </dependencies>
@@ -166,7 +166,7 @@
                                     <version>${carbon.metrics.version}</version>
                                 </bundle>
                                 <bundle>
-                                    <symbolicName>org.h2</symbolicName>
+                                    <symbolicName>h2</symbolicName>
                                     <version>${h2.version}</version>
                                 </bundle>
                             </bundles>

--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,7 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.h2database</groupId>
+                <groupId>org.wso2.orbit.com.h2database</groupId>
                 <artifactId>h2</artifactId>
                 <version>${h2.version}</version>
             </dependency>
@@ -852,7 +852,7 @@
         <slf4j.version.range>[1.7.0,1.8.0)</slf4j.version.range>
         <log4j.version>2.9.1</log4j.version>
         <hikaricp.version>2.7.2</hikaricp.version>
-        <h2.version>1.4.196</h2.version>
+        <h2.version>1.4.199.wso2v1</h2.version>
         <spring.version>5.0.1.RELEASE</spring.version>
         <mockito.version>2.11.0</mockito.version>
         <tomcat.version>9.0.1</tomcat.version>

--- a/tests/osgi-tests/pom.xml
+++ b/tests/osgi-tests/pom.xml
@@ -127,7 +127,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
+            <groupId>org.wso2.orbit.com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
## Purpose
h2 database version is updated to 1.4.199.wso2v1 and also the dependency is changed to the wso2 orbit version.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes