### PR TITLE
Fix getting NaN when retrieving the mean value in sql level for metrics

### DIFF
--- a/components/org.wso2.carbon.metrics.jdbc.reporter/src/main/java/org/wso2/carbon/metrics/jdbc/reporter/JdbcReporter.java
+++ b/components/org.wso2.carbon.metrics.jdbc.reporter/src/main/java/org/wso2/carbon/metrics/jdbc/reporter/JdbcReporter.java
@@ -408,8 +408,6 @@ public class JdbcReporter extends ScheduledReporter {
         final Snapshot snapshot = timer.getSnapshot();
         
         try {
-            logger.info("Value for snapshot.getMean() is: " + snapshot.getMean());
-            logger.info("Value for convertDuration(snapshot.getMean()) is: " + convertDuration(snapshot.getMean()));
             ps.setString(1, source);
             ps.setLong(2, timestamp);
             ps.setString(3, name);

--- a/components/org.wso2.carbon.metrics.jdbc.reporter/src/main/java/org/wso2/carbon/metrics/jdbc/reporter/JdbcReporter.java
+++ b/components/org.wso2.carbon.metrics.jdbc.reporter/src/main/java/org/wso2/carbon/metrics/jdbc/reporter/JdbcReporter.java
@@ -407,31 +407,31 @@ public class JdbcReporter extends ScheduledReporter {
     private void reportTimer(final long timestamp, PreparedStatement ps, String name, Timer timer) throws SQLException {
         final Snapshot snapshot = timer.getSnapshot();
         
-            ps.setString(1, source);
-            ps.setLong(2, timestamp);
-            ps.setString(3, name);
-            ps.setLong(4, timer.getCount());
-            ps.setDouble(5, convertDuration(snapshot.getMax()));
-            if (Double.isNaN(snapshot.getMean())) {
-                logger.warn("The mean value become NaN. Hence setting it as 0.0");
-                ps.setDouble(6, convertDuration(0.0));
-            } else {
-                ps.setDouble(6, convertDuration(snapshot.getMean()));
-            }
-            ps.setDouble(7, convertDuration(snapshot.getMin()));
-            ps.setDouble(8, convertDuration(snapshot.getStdDev()));
-            ps.setDouble(9, convertDuration(snapshot.getMedian()));
-            ps.setDouble(10, convertDuration(snapshot.get75thPercentile()));
-            ps.setDouble(11, convertDuration(snapshot.get95thPercentile()));
-            ps.setDouble(12, convertDuration(snapshot.get98thPercentile()));
-            ps.setDouble(13, convertDuration(snapshot.get99thPercentile()));
-            ps.setDouble(14, convertDuration(snapshot.get999thPercentile()));
-            ps.setDouble(15, convertRate(timer.getMeanRate()));
-            ps.setDouble(16, convertRate(timer.getOneMinuteRate()));
-            ps.setDouble(17, convertRate(timer.getFiveMinuteRate()));
-            ps.setDouble(18, convertRate(timer.getFifteenMinuteRate()));
-            ps.setString(19, String.format("calls/%s", getRateUnit()));
-            ps.setString(20, getDurationUnit());
+        ps.setString(1, source);
+        ps.setLong(2, timestamp);
+        ps.setString(3, name);
+        ps.setLong(4, timer.getCount());
+        ps.setDouble(5, convertDuration(snapshot.getMax()));
+        if (Double.isNaN(snapshot.getMean())) {
+            logger.warn("The mean value become NaN. Hence setting it as 0.0");
+            ps.setDouble(6, convertDuration(0.0));
+        } else {
+            ps.setDouble(6, convertDuration(snapshot.getMean()));
+        }
+        ps.setDouble(7, convertDuration(snapshot.getMin()));
+        ps.setDouble(8, convertDuration(snapshot.getStdDev()));
+        ps.setDouble(9, convertDuration(snapshot.getMedian()));
+        ps.setDouble(10, convertDuration(snapshot.get75thPercentile()));
+        ps.setDouble(11, convertDuration(snapshot.get95thPercentile()));
+        ps.setDouble(12, convertDuration(snapshot.get98thPercentile()));
+        ps.setDouble(13, convertDuration(snapshot.get99thPercentile()));
+        ps.setDouble(14, convertDuration(snapshot.get999thPercentile()));
+        ps.setDouble(15, convertRate(timer.getMeanRate()));
+        ps.setDouble(16, convertRate(timer.getOneMinuteRate()));
+        ps.setDouble(17, convertRate(timer.getFiveMinuteRate()));
+        ps.setDouble(18, convertRate(timer.getFifteenMinuteRate()));
+        ps.setString(19, String.format("calls/%s", getRateUnit()));
+        ps.setString(20, getDurationUnit());
     }
 
     private void rollbackTransaction(Connection connection) {

--- a/components/org.wso2.carbon.metrics.jdbc.reporter/src/main/java/org/wso2/carbon/metrics/jdbc/reporter/JdbcReporter.java
+++ b/components/org.wso2.carbon.metrics.jdbc.reporter/src/main/java/org/wso2/carbon/metrics/jdbc/reporter/JdbcReporter.java
@@ -406,27 +406,35 @@ public class JdbcReporter extends ScheduledReporter {
 
     private void reportTimer(final long timestamp, PreparedStatement ps, String name, Timer timer) throws SQLException {
         final Snapshot snapshot = timer.getSnapshot();
-
-        ps.setString(1, source);
-        ps.setLong(2, timestamp);
-        ps.setString(3, name);
-        ps.setLong(4, timer.getCount());
-        ps.setDouble(5, convertDuration(snapshot.getMax()));
-        ps.setDouble(6, convertDuration(snapshot.getMean()));
-        ps.setDouble(7, convertDuration(snapshot.getMin()));
-        ps.setDouble(8, convertDuration(snapshot.getStdDev()));
-        ps.setDouble(9, convertDuration(snapshot.getMedian()));
-        ps.setDouble(10, convertDuration(snapshot.get75thPercentile()));
-        ps.setDouble(11, convertDuration(snapshot.get95thPercentile()));
-        ps.setDouble(12, convertDuration(snapshot.get98thPercentile()));
-        ps.setDouble(13, convertDuration(snapshot.get99thPercentile()));
-        ps.setDouble(14, convertDuration(snapshot.get999thPercentile()));
-        ps.setDouble(15, convertRate(timer.getMeanRate()));
-        ps.setDouble(16, convertRate(timer.getOneMinuteRate()));
-        ps.setDouble(17, convertRate(timer.getFiveMinuteRate()));
-        ps.setDouble(18, convertRate(timer.getFifteenMinuteRate()));
-        ps.setString(19, String.format("calls/%s", getRateUnit()));
-        ps.setString(20, getDurationUnit());
+        
+        try {
+            logger.info("Value for snapshot.getMean() is: " + snapshot.getMean());
+            logger.info("Value for convertDuration(snapshot.getMean()) is: " + convertDuration(snapshot.getMean()));
+            ps.setString(1, source);
+            ps.setLong(2, timestamp);
+            ps.setString(3, name);
+            ps.setLong(4, timer.getCount());
+            ps.setDouble(5, convertDuration(snapshot.getMax()));
+            ps.setDouble(6, convertDuration(snapshot.getMean()));
+            ps.setDouble(7, convertDuration(snapshot.getMin()));
+            ps.setDouble(8, convertDuration(snapshot.getStdDev()));
+            ps.setDouble(9, convertDuration(snapshot.getMedian()));
+            ps.setDouble(10, convertDuration(snapshot.get75thPercentile()));
+            ps.setDouble(11, convertDuration(snapshot.get95thPercentile()));
+            ps.setDouble(12, convertDuration(snapshot.get98thPercentile()));
+            ps.setDouble(13, convertDuration(snapshot.get99thPercentile()));
+            ps.setDouble(14, convertDuration(snapshot.get999thPercentile()));
+            ps.setDouble(15, convertRate(timer.getMeanRate()));
+            ps.setDouble(16, convertRate(timer.getOneMinuteRate()));
+            ps.setDouble(17, convertRate(timer.getFiveMinuteRate()));
+            ps.setDouble(18, convertRate(timer.getFifteenMinuteRate()));
+            ps.setString(19, String.format("calls/%s", getRateUnit()));
+            ps.setString(20, getDurationUnit());
+        } catch (SQLException e) {
+            logger.info("Value for snapshot.getMean() is: " + snapshot.getMean());
+            logger.info("Value for convertDuration(snapshot.getMean()) is: " + convertDuration(snapshot.getMean()));
+            throw new SQLException("Exception is thrown from new catch", e);
+        }
     }
 
     private void rollbackTransaction(Connection connection) {

--- a/components/org.wso2.carbon.metrics.jdbc.reporter/src/main/java/org/wso2/carbon/metrics/jdbc/reporter/JdbcReporter.java
+++ b/components/org.wso2.carbon.metrics.jdbc.reporter/src/main/java/org/wso2/carbon/metrics/jdbc/reporter/JdbcReporter.java
@@ -407,13 +407,11 @@ public class JdbcReporter extends ScheduledReporter {
     private void reportTimer(final long timestamp, PreparedStatement ps, String name, Timer timer) throws SQLException {
         final Snapshot snapshot = timer.getSnapshot();
         
-        try {
             ps.setString(1, source);
             ps.setLong(2, timestamp);
             ps.setString(3, name);
             ps.setLong(4, timer.getCount());
             ps.setDouble(5, convertDuration(snapshot.getMax()));
-//            ps.setDouble(6, convertDuration(snapshot.getMean()));
             if (Double.isNaN(snapshot.getMean())) {
                 logger.warn("The mean value become NaN. Hence setting it as 0.0");
                 ps.setDouble(6, convertDuration(0.0));
@@ -434,11 +432,6 @@ public class JdbcReporter extends ScheduledReporter {
             ps.setDouble(18, convertRate(timer.getFifteenMinuteRate()));
             ps.setString(19, String.format("calls/%s", getRateUnit()));
             ps.setString(20, getDurationUnit());
-        } catch (SQLException e) {
-            logger.info("Value for snapshot.getMean() is: " + snapshot.getMean());
-            logger.info("Value for convertDuration(snapshot.getMean()) is: " + convertDuration(snapshot.getMean()));
-            throw new SQLException("Exception is thrown from new catch", e);
-        }
     }
 
     private void rollbackTransaction(Connection connection) {

--- a/components/org.wso2.carbon.metrics.jdbc.reporter/src/main/java/org/wso2/carbon/metrics/jdbc/reporter/JdbcReporter.java
+++ b/components/org.wso2.carbon.metrics.jdbc.reporter/src/main/java/org/wso2/carbon/metrics/jdbc/reporter/JdbcReporter.java
@@ -413,7 +413,13 @@ public class JdbcReporter extends ScheduledReporter {
             ps.setString(3, name);
             ps.setLong(4, timer.getCount());
             ps.setDouble(5, convertDuration(snapshot.getMax()));
-            ps.setDouble(6, convertDuration(snapshot.getMean()));
+//            ps.setDouble(6, convertDuration(snapshot.getMean()));
+            if (Double.isNaN(snapshot.getMean())) {
+                logger.warn("The mean value become NaN. Hence setting it as 0.0");
+                ps.setDouble(6, convertDuration(0.0));
+            } else {
+                ps.setDouble(6, convertDuration(snapshot.getMean()));
+            }
             ps.setDouble(7, convertDuration(snapshot.getMin()));
             ps.setDouble(8, convertDuration(snapshot.getStdDev()));
             ps.setDouble(9, convertDuration(snapshot.getMedian()));

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <repository>
             <id>jcenter</id>
             <name>bintray</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
## Purpose
In matrics use case of wso2sp-4.4.0 the following error log was observed and there is a special character in the log. This character was generated due to the value "Nan".

> ERROR {org.wso2.carbon.metrics.jdbc.reporter.JdbcReporter} - Error when reporting timers java.sql.SQLException: '�' is not a valid numeric or approximate numeric value

## Goals
Check for the value 'Nan' and convert it to the 0.0. This step will resolve the mentioned issue, additionally, some error handling was added.