### PR TITLE
Bump disruptor version to 3.4.2.wso2v1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -870,7 +870,7 @@
         <carbon.jndi.version>1.0.5</carbon.jndi.version>
         <carbon.datasources.version>1.1.14</carbon.datasources.version>
         <carbon.datasources.version.range>[1.1.0, 2.0.0)</carbon.datasources.version.range>
-        <disruptor.orbit.version>3.3.2.wso2v2</disruptor.orbit.version>
+        <disruptor.orbit.version>3.4.2.wso2v1</disruptor.orbit.version>
         <libthrift.wso2.version>0.9.2.wso2v1</libthrift.wso2.version>
         <commons-io.wso2.version>2.11.0.wso2v1</commons-io.wso2.version>
         <commons.pool.version>1.5.6.wso2v1</commons.pool.version>


### PR DESCRIPTION
## Purpose
> Bump disruptor version to 3.4.2.wso2v1
Issue
https://github.com/wso2/api-manager/issues/1395