### PR TITLE
Bump libthrift 0.9.2.wso2v1 -> 0.23.0.wso2v1 (CVE-2018-1320, CVE-2019-0205, CVE-2018-11798)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -878,7 +878,7 @@
         <carbon.datasources.version>1.1.18</carbon.datasources.version>
         <carbon.datasources.version.range>[1.1.0, 2.0.0)</carbon.datasources.version.range>
         <disruptor.orbit.version>3.4.2.wso2v1</disruptor.orbit.version>
-        <libthrift.wso2.version>0.9.2.wso2v1</libthrift.wso2.version>
+        <libthrift.wso2.version>0.23.0.wso2v1</libthrift.wso2.version>
         <commons-io.wso2.version>2.17.0.wso2v1</commons-io.wso2.version>
         <commons.pool.version>1.5.6.wso2v1</commons.pool.version>
         <carbon.securevault.version>5.0.20</carbon.securevault.version>


### PR DESCRIPTION
## Summary

- Upgrade `libthrift.wso2:libthrift` from `0.9.2.wso2v1` to `0.23.0.wso2v1` (orbit bundle PR wso2/orbit#1370) to fix three HIGH CVEs: CVE-2018-1320, CVE-2019-0205, CVE-2018-11798
- No Java source changes needed — the DAS reporter uses the DataBridge `DataPublisher` abstraction layer and does not make direct Thrift transport API calls

## Test plan

- [ ] Verify `libthrift_0.23.0.wso2v1.jar` present in final SI pack; `0.9.2` absent
- [ ] Run grype scan — 0 libthrift CVEs
- [ ] Smoke test DAS metrics reporting

🤖 Generated with [Claude Code](https://claude.com/claude-code)